### PR TITLE
Remove feedback and PD from portfolio template

### DIFF
--- a/template.markdown
+++ b/template.markdown
@@ -63,24 +63,7 @@
 
 (3-4 sentences summarizing your takeaways from _each_ session, including things you're continuing to think about, things you learned, things you're doing differently)
 
-
-### Professional Development Workshops
-#### (Session Name)
-
-* [Workshop URL]()
-* [Link to Completed Deliverables]()
-
-(takeaways from session)
-
 ## E: Feedback and Community Participation
-
-### Giving Feedback
-
-(feedback from me)
-
-### Being a Community Member
-
-(feedback to me)
 
 ### Playing a Part
 

--- a/template.markdown
+++ b/template.markdown
@@ -16,7 +16,7 @@
 
 ## A: End of Module Assessment
 
-(Notes & scores from your assessment rubric)
+(Indicate whether you passed or failed the end of module assessment)
 
 
 ## B: Individual Work & Projects
@@ -63,7 +63,7 @@
 
 (3-4 sentences summarizing your takeaways from _each_ session, including things you're continuing to think about, things you learned, things you're doing differently)
 
-## E: Feedback and Community Participation
+## E: Community Participation
 
 ### Playing a Part
 


### PR DESCRIPTION
* Remove professional development workshops since students are now required to submit those deliverables to Meg directly using a PR to the `career-development-curriculum` repo.
* Remove 'feedback from me' and 'feedback to me' based on understanding of privacy concerns from Allison.