### PR TITLE
Add documentation patch for Andrew Wooten

### DIFF
--- a/students/1611-back/andrew-wooten/20170608-andrew-wooten-m4.markdown
+++ b/students/1611-back/andrew-wooten/20170608-andrew-wooten-m4.markdown
@@ -89,6 +89,7 @@
 ### Projects
 
 * [GitHub URL](https://github.com/andrewdwooten/faker)
+* [Documentation patch](https://github.com/codahale/bcrypt-ruby/pull/154)
 * [Original Assignment](http://backend.turing.io/module4/lessons/contributing_to_open_source)
 
 Blog Post:


### PR DESCRIPTION
Adds link to documentation patch pursuant to Open Source assignment. I submitted a README patch to the bcrypt gem with the addition of examples of use for the has_secure_password and .authenticate methods.